### PR TITLE
HELOSK-265 Add margin-top to main content to account for larger logo in navbar

### DIFF
--- a/src/scss/layout/_front-page.scss
+++ b/src/scss/layout/_front-page.scss
@@ -177,3 +177,7 @@
     }
   }
 }
+
+#main-content {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
Logo size was requested to be increased, so it was done. As an unintended consequence, the #main-content is partially covered by the larger navbar so additional margin-top is added to offset this.