### PR TITLE
Fix/helosk 268 newsletter image

### DIFF
--- a/functions/newsletters.php
+++ b/functions/newsletters.php
@@ -20,7 +20,7 @@ function spouse_get_newsletters() {
     $args = array (
         'post_type' => 'newsletter',
         'post_status' => 'publish',
-        'posts_per_page' => 4,
+        'posts_per_page' => 6,
         'order' => 'DESC'
     );
 

--- a/functions/newsletters.php
+++ b/functions/newsletters.php
@@ -20,7 +20,7 @@ function spouse_get_newsletters() {
     $args = array (
         'post_type' => 'newsletter',
         'post_status' => 'publish',
-        'posts_per_page' => 6,
+        'posts_per_page' => 4,
         'order' => 'DESC'
     );
 
@@ -44,7 +44,7 @@ function spouse_print_newsletters($newsletters) {
                 ?>
                 <div class="newsletters-column my-3">
                   <div class="newsletter clearfix">
-                    <a href="<?php echo $pdf; ?>">
+                    <a href="<?php echo $pdf; ?>" target="_blank">
                       <div class="newsletter-content-wrap card border-0 flex-fill">
                         <div class="newsletter-content">
                           <?php if( !empty($featured_image) ): ?>

--- a/src/scss/component/_newsletters.scss
+++ b/src/scss/component/_newsletters.scss
@@ -45,6 +45,9 @@
   .newsletter-no-image {
     width: 100%;
     min-height: 200px;
+    background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
Fix issue where the default image is clipped unintendedly

Before
<img width="957" alt="image" src="https://github.com/user-attachments/assets/b9ee2d8a-25be-4761-aea8-a6bc74e5d6eb" />

After
<img width="957" alt="image" src="https://github.com/user-attachments/assets/e32d9ac8-35ef-4ce0-9d83-9fdfc0a2a6cb" />
