### PR TITLE
Fix doubling of flexible content

### DIFF
--- a/functions/newsletters.php
+++ b/functions/newsletters.php
@@ -13,7 +13,9 @@ function spouse_show_archive($atts) {
         return '';
     }
 
+    ob_start();
     spouse_print_newsletters($newsletters);
+    return ob_get_clean();
 }
 
 function spouse_get_newsletters() {


### PR DESCRIPTION
Add ob_start and ob_get_clean to prevent rendering element twice.

"The return value of a shortcode handler function is inserted into the post content output in place of the shortcode macro. Remember to use return and not echo - anything that is echoed will be output to the browser, but it won't appear in the correct place on the page."

https://codex.wordpress.org/Shortcode_API